### PR TITLE
Added Deploy to StateMesh button

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,22 @@ When using these snippets, you'd replace `{REPO-OWNER}` and `{REPO-NAME}` with t
 
 ---
 
+### StateMesh
+
+**Deploy to StateMesh** button:
+
+[![Deploy](https://console.cloud.statemesh.net/assets/layout/images/deployStateMesh_green.svg)](https://console.cloud.statemesh.net/deploy?appname={application-name}&repository={repository})
+
+**Deploy to StateMesh** code snippet:
+
+```
+[![Deploy](https://console.cloud.statemesh.net/assets/layout/images/deployStateMesh_green.svg)](https://console.cloud.statemesh.net/deploy?appname={application name}&repository={repository}&port={port}&subpath={sub-path})
+```
+
+[**Deploy to StateMesh** button documentation](https://docs.statemesh.net/deployment/button).
+
+---
+
 ## How to Use
 
 1. **Find your hosting provider**: Navigate to the desired hosting provider section above.


### PR DESCRIPTION
StateMesh is the world's first decentralized cloud infrastructure that replaces traditional data centers with a global network of crowd-sourced node operators, maintaining functionality, security, and resilience similar to AWS/GCP/Azure. We would appreciate if we can have this button in this repository! If the button is not working properly, this might be because it needs a repository parameter. You can add this sample repository in the button path and it should look like this "...&repository=https://github.com/state-mesh/samples.git". 